### PR TITLE
enable environment variable to reset path_root

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ pip install -e .  # editable install
 
 ### Data directory
 
-Either create a directory or symbolic link called `data`. All PACE and EarthCARE files will be downloaded to standard paths under this directory, so make sure you have enough storage space before you try and download dozens of matchups.
+There are two options for telling `pace-earthcare-matchups` where to store data. Option 1: create a directory or symbolic link called `data` under the root directory of the repo. Option 2: set the environment variable `PACE_EARTHCARE_DATA_PATH` to the desired location.
+
+All PACE and EarthCARE files will be downloaded to standard paths under this directory, so make sure you have enough storage space before you try and download dozens of matchups.
 
 ### ESA MAAP token
 

--- a/src/pace_earthcare_matchups/path_utils.py
+++ b/src/pace_earthcare_matchups/path_utils.py
@@ -5,7 +5,7 @@ from maap.Result import Granule
 from pystac.item import Item
 
 PATH_ROOT = (Path(__file__) / ".." / ".." / "..").resolve()
-PATH_DATA = Path(os.getenv("PACE_DATA_PATH", PATH_ROOT / "data")).resolve()
+PATH_DATA = Path(os.getenv("PACE_EARTHCARE_DATA_PATH", PATH_ROOT / "data")).resolve()
 PATH_TOKEN = (PATH_ROOT / "token.txt").resolve()
 
 


### PR DESCRIPTION
Since I need to deal with large amount of data, and also read them through another script, it is very important to have the flexibility to save matchup L2 data into a customized directory. To achieve this, while not changing the function, now it can be reset through environment parameter before loading get_matchups
```
import os
os.environ['PACE_ROOT_PATH'] = './test1/'
from pace_earthcare_matchups.path_utils import PATH_DATA, get_path
print("Verify new path:", PATH_DATA)
from pace_earthcare_matchups.matchup import get_matchups
```